### PR TITLE
Allow for other scopes besides user & data

### DIFF
--- a/src/common/transport/transport-client.js
+++ b/src/common/transport/transport-client.js
@@ -3,13 +3,20 @@ const rp = require('request-promise-native');
 const debug = require('debug')('domo-sdk');
 
 class TransportClient {
-  constructor(clientId, clientSecret, host) {
+  constructor(clientId, clientSecret, host, scope) {
     if (!clientId || !clientSecret) throw new TransportClientError('Missing required API credentials');
 
     this.apiHost = `https://${host || 'api.domo.com'}`;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.accessToken = '';
+    if (this.scope === undefined) {
+      this.scope = 'data user';
+    } else if (Array.isArray(scope)) {
+      this.scope = scope.join(' ');
+    } else {
+      this.scope = scope;
+    }
   }
 
   addAuthHeaders(baseHeaders) {
@@ -33,7 +40,7 @@ class TransportClient {
   }
 
   _renewAccessToken() {
-    const qs = { grant_type: 'client_credentials', scope: 'data user' };
+    const qs = { grant_type: 'client_credentials', scope: this.scope };
     return this.request('/oauth/token', 'GET', {}, qs)
       .auth(this.clientId, this.clientSecret)
       .then(res => { this.accessToken = res.access_token; });

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ const UserClient = require('./users');
 const GroupClient = require('./groups');
 
 class Domo {
-  constructor(clientId, clientSecret, host) {
-    this.transport = new TransportClient(clientId, clientSecret, host);
+  constructor(clientId, clientSecret, host, scope) {
+    this.transport = new TransportClient(clientId, clientSecret, host, scope);
     this.datasets = new DatasetClient(this.transport);
     this.streams = new StreamClient(this.transport);
     this.users = new UserClient(this.transport);


### PR DESCRIPTION
I wanted to allow credentials that have only `user` or only `data` scope to use the API.

In the constructor, you can place an array `['user', 'data'] /* or */ ['user'] etc.` or you can place a string `'user data' /* or */ 'user' etc`