### PR TITLE
fixes compressed upload

### DIFF
--- a/src/streams/StreamClient.ts
+++ b/src/streams/StreamClient.ts
@@ -96,7 +96,10 @@ export default class StreamClient {
   uploadCompressedPart(id: string, exec: number, part: number, data: string): Promise<StreamExecution> {
     const req: Request = {
       url: `${this.urlBase}/${id}/executions/${exec}/part/${part}`,
-      headers: { 'Content-Type': 'application/gzip' },
+      headers: {
+                'Content-Type': 'text/csv',
+                'Content-Encoding': 'gzip'
+      },
       body: data,
     };
 


### PR DESCRIPTION
for compressed uploads you need to set content-type text/csv, and add content-enoding header. see also https://developer.domo.com/docs/stream/quickstart.